### PR TITLE
marshals set type

### DIFF
--- a/silverberg/marshal.py
+++ b/silverberg/marshal.py
@@ -84,6 +84,8 @@ def marshal(term):
         # If the datetime is naive, then it is considered UTC time and stored. If it is
         # timezone-aware, then its corresponding UTC time is stored
         return str(int(calendar.timegm(term.utctimetuple()) * 1000 + term.microsecond / 1e3))
+    elif isinstance(term, sortedset):
+        return '{%s}' % (','.join(map(marshal, term)))
     else:
         return str(term)
 

--- a/silverberg/marshal.py
+++ b/silverberg/marshal.py
@@ -85,7 +85,9 @@ def marshal(term):
         # timezone-aware, then its corresponding UTC time is stored
         return str(int(calendar.timegm(term.utctimetuple()) * 1000 + term.microsecond / 1e3))
     elif isinstance(term, sortedset):
-        return '{%s}' % (','.join(map(marshal, term)))
+        # python str() produces: set([1, 2, 3]), while cassandra wants: {1, 2, 3}
+        # so we have to marshal each element one by one.
+        return '{%s}' % (', '.join(map(marshal, term)))
     else:
         return str(term)
 

--- a/silverberg/marshal.py
+++ b/silverberg/marshal.py
@@ -84,7 +84,7 @@ def marshal(term):
         # If the datetime is naive, then it is considered UTC time and stored. If it is
         # timezone-aware, then its corresponding UTC time is stored
         return str(int(calendar.timegm(term.utctimetuple()) * 1000 + term.microsecond / 1e3))
-    elif isinstance(term, sortedset):
+    elif isinstance(term, set) or isinstance(term, sortedset):
         # python str() produces: set([1, 2, 3]), while cassandra wants: {1, 2, 3}
         # so we have to marshal each element one by one.
         return '{%s}' % (', '.join(map(marshal, term)))

--- a/silverberg/test/test_marshal.py
+++ b/silverberg/test/test_marshal.py
@@ -119,6 +119,15 @@ class MarshallingUnmarshallingSet(TestCase):
     """
     Test marshalling and unmarshalling of sets
     """
+    def test_marshal_set(self):
+        to_marshal = sortedset([])
+        self.assertEqual(marshal(to_marshal), '{}')
+        # the order of elements in set might change
+        to_marshal = sortedset([1, 2])
+        self.assertIn(marshal(to_marshal), {'{1, 2}', '{2, 1}'})
+        to_marshal = sortedset(['1', '2'])
+        self.assertIn(marshal(to_marshal), {"{'1', '2'}", "{'2', '1'}"})
+
     def test_unmarshal_set(self):
         marshalled_value_pairs = (
             ('\x00\x00', INTEGER_TYPE, sortedset()),


### PR DESCRIPTION
#53 complains that set type is not well marshalled. I figured out it's because python str representation of set type is not what cassandra needs.
python str() produces:
```
>>> s = {1, 2, 3}
>>> str(s)
'set([1, 2, 3])'
```
but cassandra wants `{1, 2, 3}`. So we have to marshal set elements one by one.